### PR TITLE
Use WebViewWidget with controller in checkout webview

### DIFF
--- a/packages/app_consumer/lib/screens/checkout_webview.dart
+++ b/packages/app_consumer/lib/screens/checkout_webview.dart
@@ -14,6 +14,7 @@ class _CheckoutWebViewState extends State<CheckoutWebView> {
   StreamSubscription<Uri>? _sub;
   late final AppLinks _appLinks;
   bool _done = false;
+  late final WebViewController _controller;
 
   @override
   void initState() {
@@ -27,6 +28,9 @@ class _CheckoutWebViewState extends State<CheckoutWebView> {
         if (mounted) Navigator.of(context).pop(uri.path.contains('success'));
       }
     });
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse(widget.url));
   }
 
   @override
@@ -39,9 +43,8 @@ class _CheckoutWebViewState extends State<CheckoutWebView> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Checkout')),
-      body: WebView(
-        initialUrl: widget.url,
-        javascriptMode: JavascriptMode.unrestricted,
+      body: WebViewWidget(
+        controller: _controller,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Replace deprecated WebView with WebViewWidget driven by WebViewController
- Enable JavaScript and load initial checkout URL via controller

## Testing
- `dart format packages/app_consumer/lib/screens/checkout_webview.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart analyze packages/app_consumer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f031be4832ea801a57fb705964b