### PR TITLE
refactor: switch to WebViewWidget in checkout webview

### DIFF
--- a/packages/app_consumer/lib/screens/checkout_webview.dart
+++ b/packages/app_consumer/lib/screens/checkout_webview.dart
@@ -14,11 +14,15 @@ class _CheckoutWebViewState extends State<CheckoutWebView> {
   StreamSubscription<Uri>? _sub;
   late final AppLinks _appLinks;
   bool _done = false;
+  late final WebViewController _controller;
 
   @override
   void initState() {
     super.initState();
     _appLinks = AppLinks();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadRequest(Uri.parse(widget.url));
     _sub = _appLinks.uriLinkStream.listen((uri) {
       if (_done) return;
       if (uri.host == 'checkout' &&
@@ -39,10 +43,7 @@ class _CheckoutWebViewState extends State<CheckoutWebView> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Checkout')),
-      body: WebView(
-        initialUrl: widget.url,
-        javascriptMode: JavascriptMode.unrestricted,
-      ),
+      body: WebViewWidget(controller: _controller),
     );
   }
 }

--- a/packages/app_consumer/lib/screens/checkout_webview.dart
+++ b/packages/app_consumer/lib/screens/checkout_webview.dart
@@ -12,18 +12,17 @@ class CheckoutWebView extends StatefulWidget {
 
 class _CheckoutWebViewState extends State<CheckoutWebView> {
   StreamSubscription<Uri>? _sub;
-  late final AppLinks _appLinks;
   bool _done = false;
   late final WebViewController _controller;
 
   @override
   void initState() {
     super.initState();
-    _appLinks = AppLinks();
+    final appLinks = AppLinks();
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..loadRequest(Uri.parse(widget.url));
-    _sub = _appLinks.uriLinkStream.listen((uri) {
+    _sub = appLinks.uriLinkStream.listen((uri) {
       if (_done) return;
       if (uri.host == 'checkout' &&
           (uri.path.contains('success') || uri.path.contains('cancel'))) {


### PR DESCRIPTION
## Summary
- use `WebViewWidget` with a `WebViewController` for checkout
- fix JavaScript mode constant casing

## Testing
- `dart format packages/app_consumer/lib/screens/checkout_webview.dart`
- `dart analyze packages/app_consumer` *(fails: Target of URI doesn't exist...)*

------
https://chatgpt.com/codex/tasks/task_e_68b044927f48832e9863932de7be24f9